### PR TITLE
add support for editable content type

### DIFF
--- a/files.go
+++ b/files.go
@@ -98,17 +98,26 @@ func (b *Bucket) UploadHashedFile(name string, meta map[string]string, file io.R
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", auth.AuthorizationToken)
+
+	req.Header.Set("Authorization", auth.AuthorizationToken)
 
 	// Set file metadata
 	req.ContentLength = contentLength
-	req.Header.Add("Content-Type", "b2/x-auto")
-	req.Header.Add("X-Bz-File-Name", url.QueryEscape(name))
-	req.Header.Add("X-Bz-Content-Sha1", sha1Hash)
+	// default content type
+	req.Header.Set("Content-Type", "b2/x-auto")
+	req.Header.Set("X-Bz-File-Name", url.QueryEscape(name))
+	req.Header.Set("X-Bz-Content-Sha1", sha1Hash)
 
 	if meta != nil {
 		for k, v := range meta {
-			req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
+			// add support for editable content-type;
+			// set the rest of headers as X-Bz-Info-* to preserve backwards
+			// compatibility
+			if strings.ToLower(k) == "content-type" {
+				req.Header.Set("Content-Type", url.QueryEscape(v))
+			} else {
+				req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
+			}
 		}
 	}
 

--- a/files.go
+++ b/files.go
@@ -114,7 +114,7 @@ func (b *Bucket) UploadHashedFile(name string, meta map[string]string, file io.R
 			// set the rest of headers as X-Bz-Info-* to preserve backwards
 			// compatibility
 			if strings.ToLower(k) == "content-type" {
-				req.Header.Set("Content-Type", url.QueryEscape(v))
+				req.Header.Set("Content-Type", v)
 			} else {
 				req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
 			}


### PR DESCRIPTION
Added support for editable content-type and also, added a minor refactoring to the `Authorization`, `Content-Type`, `X-Bz-File-Name` and `X-Bz-Content-Sha1` headers. 

Modified the method used for setting the aforementioned headers from `Add` to `Set` because those should be single-value headers - the backend doesn't support multiple values for those headers.

So for example, the `Content-Type` header is set default to `b2/x-auto` and if the client sets this field to another value within the metadata parameter, by using the `Add` method, both the default option and the client used option will be sent. Hence, the content type will be set to `b2/x-auto,user/selected-content-type` - which is not supported by the backend api.
