### PR TITLE
Pfzero editable content type

### DIFF
--- a/files.go
+++ b/files.go
@@ -98,17 +98,26 @@ func (b *Bucket) UploadHashedFile(name string, meta map[string]string, file io.R
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", auth.AuthorizationToken)
+
+	req.Header.Set("Authorization", auth.AuthorizationToken)
 
 	// Set file metadata
 	req.ContentLength = contentLength
-	req.Header.Add("Content-Type", "b2/x-auto")
-	req.Header.Add("X-Bz-File-Name", url.QueryEscape(name))
-	req.Header.Add("X-Bz-Content-Sha1", sha1Hash)
+	// default content type
+	req.Header.Set("Content-Type", "b2/x-auto")
+	req.Header.Set("X-Bz-File-Name", url.QueryEscape(name))
+	req.Header.Set("X-Bz-Content-Sha1", sha1Hash)
 
 	if meta != nil {
 		for k, v := range meta {
-			req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
+			// add support for editable content-type;
+			// set the rest of headers as X-Bz-Info-* to preserve backwards
+			// compatibility
+			if strings.ToLower(k) == "content-type" {
+				req.Header.Set("Content-Type", url.QueryEscape(v))
+			} else {
+				req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
+			}
 		}
 	}
 

--- a/files.go
+++ b/files.go
@@ -114,7 +114,7 @@ func (b *Bucket) UploadHashedFile(name string, meta map[string]string, file io.R
 			// set the rest of headers as X-Bz-Info-* to preserve backwards
 			// compatibility
 			if strings.ToLower(k) == "content-type" {
-				req.Header.Set("Content-Type", url.QueryEscape(v))
+				req.Header.Set("Content-Type", v)
 			} else {
 				req.Header.Add("X-Bz-Info-"+url.QueryEscape(k), url.QueryEscape(v))
 			}


### PR DESCRIPTION
@pfzero, Building on your changes, I've added new Upload method signatures
which allow the caller to specify the contentType. This seems safer, as it will
not change the behaviour of any existing users setting X-Bz-Content-Type,
unlikely as that may be.

By keeping the metadata to just X-Bz-\* values, we don't have to explain the special
case behaviour for Content-Type.

Can you check and see if it still accomplishes what you need from #8 ?
