### PR TITLE
Get a separate upload URL for each upload request

### DIFF
--- a/apitypes.go
+++ b/apitypes.go
@@ -18,8 +18,19 @@ func (e B2Error) Error() string {
 // IsFatal returns true if this error represents
 // an error which can't be recovered from by retrying
 func (e *B2Error) IsFatal() bool {
-	switch e.Status {
-	case 401:
+	switch {
+	case e.Status == 401: // Unauthorized
+		switch e.Code {
+		case "expired_auth_token":
+			return false
+		case "missing_auth_token", "bad_auth_token":
+			return true
+		default:
+			return true
+		}
+	case e.Status == 408: // Timeout
+		return false
+	case e.Status >= 500 && e.Status < 600: // Server error
 		return false
 	default:
 		return true

--- a/backblaze.go
+++ b/backblaze.go
@@ -230,6 +230,9 @@ func (c *B2) parseResponse(resp *http.Response, result interface{}, auth *author
 	case 200: // Response is OK
 	case 401:
 		auth.invalidate()
+		if err := c.parseError(body); err != nil {
+			return err
+		}
 		return &B2Error{
 			Code:    "UNAUTHORIZED",
 			Message: "The account ID is wrong, the account does not have B2 enabled, or the application key is not valid",

--- a/backblaze_test.go
+++ b/backblaze_test.go
@@ -56,9 +56,9 @@ func toJSON(o interface{}) string {
 }
 
 func TestUnauthorizedError(T *testing.T) {
-	err := &B2Error{Status: 401}
+	err := &B2Error{Status: 401, Code: "expired_auth_token"}
 	if err.IsFatal() {
-		T.Fatal("401 error should not be considered fatal")
+		T.Fatal("401 expired_auth_token error should not be considered fatal")
 	}
 }
 
@@ -120,7 +120,7 @@ func TestReAuth(T *testing.T) {
 		}},
 		{401, B2Error{
 			Status:  401,
-			Code:    "UNAUTHORIZED",
+			Code:    "expired_auth_token",
 			Message: "Authentication token expired",
 		}},
 		{200, authorizeAccountResponse{

--- a/buckets.go
+++ b/buckets.go
@@ -12,6 +12,7 @@ type Bucket struct {
 	b2 *B2
 }
 
+// UploadAuth encapsulates the details needed to upload a file to B2
 type UploadAuth struct {
 	AuthorizationToken string
 	UploadURL          *url.URL

--- a/files.go
+++ b/files.go
@@ -98,7 +98,7 @@ func (b *Bucket) UploadHashedTypedFile(
 	name, contentType string, meta map[string]string, file io.Reader,
 	sha1Hash string, contentLength int64) (*File, error) {
 
-	auth, err := b.getUploadAuth()
+	auth, err := b.GetUploadAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (b *Bucket) UploadHashedTypedFile(
 	}
 
 	// Create authorized request
-	req, err := http.NewRequest("POST", auth.uploadURL.String(), file)
+	req, err := http.NewRequest("POST", auth.UploadURL.String(), file)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (b *Bucket) UploadHashedTypedFile(
 
 	resp, err := b.b2.httpClient.Do(req)
 	if err != nil {
-		auth.invalidate()
+		auth.Valid = false
 		return nil, err
 	}
 
@@ -141,10 +141,9 @@ func (b *Bucket) UploadHashedTypedFile(
 
 	// We are not dealing with the b2 client auth token in this case, hence the nil auth
 	if err := b.b2.parseResponse(resp, result, nil); err != nil {
-		auth.invalidate()
+		auth.Valid = false
 		return nil, err
 	}
-	b.returnUploadAuth(auth)
 
 	if sha1Hash != result.ContentSha1 {
 		return nil, errors.New("SHA1 of uploaded file does not match local hash")

--- a/files_test.go
+++ b/files_test.go
@@ -20,7 +20,7 @@ func TestDownloadReAuth(T *testing.T) {
 		}},
 		{401, B2Error{
 			Status:  401,
-			Code:    "UNAUTHORIZED",
+			Code:    "expired_auth_token",
 			Message: "Authentication token expired",
 		}},
 		{200, authorizeAccountResponse{


### PR DESCRIPTION
When using the provided Upload<X>File methods, upload URLs will be returned
to a pool for re-use to avoid an extra call for each file when uploading many files.

Error code recognition for fatal vs. non-fatal errors has been updated to include more
non-fatal cases according to the upload documentation.

This closes #9 
