### PR TITLE
Updated Go versions in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ os:
   - osx
 
 go:
-  - 1.5
-  - 1.6
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
   - tip
 
 before_install:


### PR DESCRIPTION
ffjson requires support for SetEscapeHTML in json.Encoder which did not exist in versions before 1.7.