### PR TITLE
Readahead support for faster file downloads

### DIFF
--- a/apitest/apitest.go
+++ b/apitest/apitest.go
@@ -24,6 +24,7 @@ type Options struct {
 
 	// Bucket
 	Bucket string `short:"b" long:"bucket" description:"The bucket name to use for testing (a random bucket name will be chosen if not specified)"`
+	Debug  bool   `short:"d" long:"debug" description:"Show debug information during test"`
 }
 
 var opts = &Options{}
@@ -46,7 +47,7 @@ func main() {
 		AccountID:      opts.AccountID,
 		ApplicationKey: opts.ApplicationKey,
 	})
-	b2.Debug = true
+	b2.Debug = opts.Debug
 	check(err)
 
 	b := testBucketCreate(b2)

--- a/apitest/apitest.go
+++ b/apitest/apitest.go
@@ -46,6 +46,7 @@ func main() {
 		AccountID:      opts.AccountID,
 		ApplicationKey: opts.ApplicationKey,
 	})
+	b2.Debug = true
 	check(err)
 
 	b := testBucketCreate(b2)
@@ -53,6 +54,7 @@ func main() {
 	// Test basic file operations
 	f, data := testFileUpload(b)
 	testFileDownload(b, f, data)
+	testFileRangeDownload(b, f, data)
 	testFileDelete(b, f)
 
 	// Test file listing calls
@@ -112,6 +114,20 @@ func testFileDownload(b *backblaze.Bucket, f *backblaze.File, data []byte) {
 	}
 
 	log.Print("File downloaded")
+}
+
+func testFileRangeDownload(b *backblaze.Bucket, f *backblaze.File, data []byte) {
+	f, reader, err := b.DownloadFileRangeByName(f.Name, &backblaze.FileRange{Start: 100, End: 2000})
+	check(err)
+
+	body, err := ioutil.ReadAll(reader)
+	check(err)
+
+	if !bytes.Equal(body, data[100:2000+1]) {
+		log.Fatal("Downloaded file range does not match upload")
+	}
+
+	log.Print("File range downloaded")
 }
 
 func testFileDelete(b *backblaze.Bucket, f *backblaze.File) {

--- a/apitypes.go
+++ b/apitypes.go
@@ -155,6 +155,12 @@ type File struct {
 	UploadTimestamp int64             `json:"uploadTimestamp"`
 }
 
+// FileRange describes a range of bytes in a file by its 0-based start and end position (inclusive)
+type FileRange struct {
+	Start int64
+	End   int64
+}
+
 type listFilesRequest struct {
 	BucketID      string `json:"bucketId"`
 	StartFileName string `json:"startFileName"`

--- a/b2/b2.go
+++ b/b2/b2.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -27,6 +28,7 @@ var opts = &Options{}
 var parser = flags.NewParser(opts, flags.Default)
 
 func main() {
+	flag.Parse()
 	_, err := parser.Parse()
 	if err != nil {
 		os.Exit(1)

--- a/buckets_test.go
+++ b/buckets_test.go
@@ -10,13 +10,13 @@ func TestListBuckets(T *testing.T) {
 	bucketID := "bucketid"
 
 	client, server := prepareResponses([]response{
-		{200, authorizeAccountResponse{
+		{code: 200, body: authorizeAccountResponse{
 			AccountID:          accountID,
 			APIEndpoint:        "http://api.url",
 			AuthorizationToken: "testToken",
 			DownloadURL:        "http://download.url",
 		}},
-		{200, listBucketsResponse{
+		{code: 200, body: listBucketsResponse{
 			Buckets: []*BucketInfo{
 				&BucketInfo{
 					ID:         bucketID,

--- a/files_test.go
+++ b/files_test.go
@@ -60,7 +60,7 @@ func TestDownloadFileRange(T *testing.T) {
 			DownloadURL:        "http://download.url",
 		}},
 		{code: 200, body: testFile[0:4], headers: map[string]string{
-			"Content-Range": "bytes=0-3",
+			"Content-Range": "bytes 0-3/13",
 		}},
 	})
 	defer server.Close()

--- a/files_test.go
+++ b/files_test.go
@@ -1,9 +1,94 @@
 package backblaze
 
 import (
+	"bytes"
 	"io/ioutil"
 	"testing"
 )
+
+func TestDownloadFile(T *testing.T) {
+
+	accountID := "test"
+	testFile := []byte("File contents")
+
+	client, server := prepareResponses([]response{
+		{code: 200, body: authorizeAccountResponse{
+			AccountID:          accountID,
+			APIEndpoint:        "http://api.url",
+			AuthorizationToken: "testToken",
+			DownloadURL:        "http://download.url",
+		}},
+		{code: 200, body: testFile},
+	})
+	defer server.Close()
+
+	b2 := &B2{
+		Credentials: Credentials{
+			AccountID:      accountID,
+			ApplicationKey: "test",
+		},
+		Debug:      testing.Verbose(),
+		httpClient: *client,
+		host:       server.URL,
+	}
+
+	_, reader, err := b2.DownloadFileRangeByID("fileId", &FileRange{0, 3})
+	if err != nil {
+		T.Fatal(err)
+	} else {
+		defer reader.Close()
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			T.Fatal(err)
+		}
+		if !bytes.Equal(body, testFile) {
+			T.Errorf("Expected file contents to be [%s], saw [%s]", testFile[0:4], body)
+		}
+	}
+}
+
+func TestDownloadFileRange(T *testing.T) {
+
+	accountID := "test"
+	testFile := []byte("File contents")
+
+	client, server := prepareResponses([]response{
+		{code: 200, body: authorizeAccountResponse{
+			AccountID:          accountID,
+			APIEndpoint:        "http://api.url",
+			AuthorizationToken: "testToken",
+			DownloadURL:        "http://download.url",
+		}},
+		{code: 200, body: testFile[0:4], headers: map[string]string{
+			"Content-Range": "bytes=0-3",
+		}},
+	})
+	defer server.Close()
+
+	b2 := &B2{
+		Credentials: Credentials{
+			AccountID:      accountID,
+			ApplicationKey: "test",
+		},
+		Debug:      testing.Verbose(),
+		httpClient: *client,
+		host:       server.URL,
+	}
+
+	_, reader, err := b2.DownloadFileRangeByID("fileId", &FileRange{0, 3})
+	if err != nil {
+		T.Fatal(err)
+	} else {
+		defer reader.Close()
+		body, err := ioutil.ReadAll(reader)
+		if err != nil {
+			T.Fatal(err)
+		}
+		if !bytes.Equal(body, testFile[0:4]) {
+			T.Errorf("Expected file contents to be [%s], saw [%s]", testFile[0:4], body)
+		}
+	}
+}
 
 func TestDownloadReAuth(T *testing.T) {
 
@@ -12,24 +97,24 @@ func TestDownloadReAuth(T *testing.T) {
 	testFile := "File contents"
 
 	client, server := prepareResponses([]response{
-		{200, authorizeAccountResponse{
+		{code: 200, body: authorizeAccountResponse{
 			AccountID:          accountID,
 			APIEndpoint:        "http://api.url",
 			AuthorizationToken: "testToken",
 			DownloadURL:        "http://download.url",
 		}},
-		{401, B2Error{
+		{code: 401, body: B2Error{
 			Status:  401,
 			Code:    "expired_auth_token",
 			Message: "Authentication token expired",
 		}},
-		{200, authorizeAccountResponse{
+		{code: 200, body: authorizeAccountResponse{
 			AccountID:          accountID,
 			APIEndpoint:        "http://api.url",
 			AuthorizationToken: token2,
 			DownloadURL:        "http://download.url",
 		}},
-		{200, testFile},
+		{code: 200, body: testFile},
 	})
 	defer server.Close()
 


### PR DESCRIPTION
Add support for partial file download using Content-Range requests.

This allows use of the google/readahead library to perform parallel requests for multiple file chunks in parallel.

Closes #19 