### PR TITLE
add concurrent queue for reusing UploadAuth

### DIFF
--- a/files.go
+++ b/files.go
@@ -164,6 +164,9 @@ func (b *Bucket) UploadHashedTypedFile(
 		return nil, err
 	}
 
+	// Place the UploadAuth back in the pool
+	b.ReturnUploadAuth(auth)
+
 	result := &File{}
 
 	// We are not dealing with the b2 client auth token in this case, hence the nil auth


### PR DESCRIPTION
This was the simplest implementation i could think of. 

It will keep a queue of 100 idle upload urls and create a new one only if one is not present on the queue. If one fails, it should not be added back to the queue.

I am not completely sure about the implementation of the return, but since UploadAuth is exported, it made sense to export return also.

Let me know what you think and modify as you see fit.

