### PR TITLE
Allow custom http clients

### DIFF
--- a/backblaze.go
+++ b/backblaze.go
@@ -47,7 +47,7 @@ type B2 struct {
 	mutex      sync.Mutex
 	host       string
 	auth       *authorizationState
-	httpClient http.Client
+	httpClient *http.Client
 }
 
 // The current auth state of the client. Can be individually invalidated by
@@ -88,9 +88,17 @@ func (a *authorizationState) invalidate() {
 // NewB2 creates a new Client for accessing the B2 API.
 // The AuthorizeAccount method will be called immediately.
 func NewB2(creds Credentials) (*B2, error) {
+
+	return NewB2WithHTTPClient(creds, &http.Client{})
+}
+
+// NewB2WithHTTPClient creates a new Client for accessing the B2 API with a custom http.Client
+// The AuthorizeAccount method will be called immediately.
+func NewB2WithHTTPClient(creds Credentials, httpclient *http.Client) (*B2, error) {
 	c := &B2{
 		Credentials:    creds,
 		MaxIdleUploads: 10,
+		httpClient:     httpclient,
 	}
 
 	// Authorize account

--- a/backblaze.go
+++ b/backblaze.go
@@ -39,6 +39,10 @@ type B2 struct {
 	// If true, display debugging information about API calls
 	Debug bool
 
+	// Number of MaxIdleUploads to keep for reuse.
+	// This must be set prior to creating a bucket struct
+	MaxIdleUploads int
+
 	// State
 	mutex      sync.Mutex
 	host       string
@@ -85,7 +89,8 @@ func (a *authorizationState) invalidate() {
 // The AuthorizeAccount method will be called immediately.
 func NewB2(creds Credentials) (*B2, error) {
 	c := &B2{
-		Credentials: creds,
+		Credentials:    creds,
+		MaxIdleUploads: 10,
 	}
 
 	// Authorize account

--- a/buckets.go
+++ b/buckets.go
@@ -48,7 +48,7 @@ func (b *B2) CreateBucketWithInfo(bucketName string, bucketType BucketType, buck
 
 	bucket := &Bucket{
 		BucketInfo:     response,
-		uploadAuthPool: make(chan *UploadAuth, 100),
+		uploadAuthPool: make(chan *UploadAuth, b.MaxIdleUploads),
 		b2:             b,
 	}
 
@@ -70,7 +70,7 @@ func (b *B2) deleteBucket(bucketID string) (*Bucket, error) {
 
 	return &Bucket{
 		BucketInfo:     response,
-		uploadAuthPool: make(chan *UploadAuth, 100),
+		uploadAuthPool: make(chan *UploadAuth, b.MaxIdleUploads),
 		b2:             b,
 	}, nil
 }
@@ -99,7 +99,7 @@ func (b *B2) ListBuckets() ([]*Bucket, error) {
 	for i, info := range response.Buckets {
 		bucket := &Bucket{
 			BucketInfo:     info,
-			uploadAuthPool: make(chan *UploadAuth, 100),
+			uploadAuthPool: make(chan *UploadAuth, b.MaxIdleUploads),
 			b2:             b,
 		}
 
@@ -127,7 +127,7 @@ func (b *B2) updateBucket(request *updateBucketRequest) (*Bucket, error) {
 
 	return &Bucket{
 		BucketInfo:     response,
-		uploadAuthPool: make(chan *UploadAuth, 100),
+		uploadAuthPool: make(chan *UploadAuth, b.MaxIdleUploads),
 		b2:             b,
 	}, nil
 }


### PR DESCRIPTION
Allow custom http.Clients so users can handle errors and retries with custom transports.