### PR TITLE
added new Bucket::CopyFile method (b2_copy_file API method wrapper)

### DIFF
--- a/apitypes.go
+++ b/apitypes.go
@@ -189,10 +189,24 @@ type ListFileVersionsResponse struct {
 	NextFileID   string       `json:"nextFileId"`
 }
 
+type fileCopyRequest struct {
+	ID                  string                `json:"sourceFileId"`
+	Name                string                `json:"fileName"`
+	MetadataDirective   FileMetadataDirective `json:"metadataDirective"`
+	DestinationBucketID string                `json:"destinationBucketId"`
+}
+
 type hideFileRequest struct {
 	BucketID string `json:"bucketId"`
 	FileName string `json:"fileName"`
 }
+
+type FileMetadataDirective string
+
+const (
+	FileMetaDirectiveCopy    FileMetadataDirective = "COPY"
+	FileMetaDirectiveReplace FileMetadataDirective = "REPLACE"
+)
 
 // FileAction indicates the current status of a file in a B2 bucket
 type FileAction string

--- a/files.go
+++ b/files.go
@@ -182,6 +182,29 @@ func (b *Bucket) UploadHashedTypedFile(
 	return result, nil
 }
 
+// CopyFile copies file
+//
+// If destination bucket is empty, file will be copy to the current file's bucket
+func (b *Bucket) CopyFile(fileID, fileName, destinationBucketId string, metadataDirective FileMetadataDirective) (*File, error) {
+	request := &fileCopyRequest{
+		ID:                fileID,
+		Name:              fileName,
+		MetadataDirective: metadataDirective,
+	}
+
+	if destinationBucketId != "" {
+		request.DestinationBucketID = destinationBucketId
+	}
+
+	response := &File{}
+
+	if err := b.b2.apiRequest("b2_copy_file", request, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 // GetFileInfo retrieves information about one file stored in B2.
 func (b *Bucket) GetFileInfo(fileID string) (*File, error) {
 	request := &fileRequest{


### PR DESCRIPTION
Hi.

There are changes which adds new API method wrapper to copy file between buckets (method's description: https://www.backblaze.com/b2/docs/b2_copy_file.html).

Best regards!