### PR TITLE
fix: omit destinationBucketId field when empty

### DIFF
--- a/apitypes.go
+++ b/apitypes.go
@@ -193,7 +193,7 @@ type fileCopyRequest struct {
 	ID                  string                `json:"sourceFileId"`
 	Name                string                `json:"fileName"`
 	MetadataDirective   FileMetadataDirective `json:"metadataDirective"`
-	DestinationBucketID string                `json:"destinationBucketId"`
+	DestinationBucketID string                `json:"destinationBucketId,omitempty"`
 }
 
 type hideFileRequest struct {


### PR DESCRIPTION
This fix "Bad destinationBucketId: " when copy file without destinationBucketId field.